### PR TITLE
Add charset detection to decoder 

### DIFF
--- a/extractor.go
+++ b/extractor.go
@@ -6,6 +6,8 @@ import (
 	"log"
 	"strconv"
 	"strings"
+
+	"golang.org/x/net/html/charset"
 )
 
 var nameMapper = map[string]string{
@@ -37,6 +39,7 @@ func (ex *Extractor) extract() error {
 	ex.globalNodeMap = make(map[string]*Node)
 
 	decoder := xml.NewDecoder(ex.reader)
+	decoder.CharsetReader = charset.NewReaderLabel
 
 	ex.root = new(Node)
 	ex.root.initialize("root", "", "", nil)


### PR DESCRIPTION
Add charset detection for remove errors like this:
extractor.go:58: xml: encoding "windows-1251" declared but Decoder.CharsetReader is nil

